### PR TITLE
sys/net: include misplacement inside linkage-specification

### DIFF
--- a/sys/include/net/sock/tcp.h
+++ b/sys/include/net/sock/tcp.h
@@ -541,11 +541,11 @@ ssize_t sock_tcp_read(sock_tcp_t *sock, void *data, size_t max_len,
  */
 ssize_t sock_tcp_write(sock_tcp_t *sock, const void *data, size_t len);
 
-#include "sock_types.h"
-
 #ifdef __cplusplus
 }
 #endif
+
+#include "sock_types.h"
 
 #endif /* NET_SOCK_TCP_H */
 /** @} */


### PR DESCRIPTION
The include "sock_types.h" should be outside of the linkage-specification.

```C++
extern "C"
{
   // #include "sock_types.h"
}

#include "sock_types.h" // outside
```

The header "sock_types.h" has his own linkage-specification.
Otherwise this leads to problems in IntelliSense in VS Code.


